### PR TITLE
feat: astro-micro redesign + canonical trailing-slash URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ pnpm-debug.log*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+.gstack/

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,94 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-06-09T00:00:00Z",
+  "title": "Design System: Fausto Moya",
+  "extensions": {
+    "colorMeta": {
+      "ink-light": { "role": "primary", "displayName": "Ink", "canonical": "#000000", "tonalRamp": ["#000000", "#171717", "#2e2e2e", "#525252", "#737373", "#a3a3a3", "#d4d4d4", "#f5f5f5"] },
+      "surface-light": { "role": "neutral", "displayName": "Paper", "canonical": "#f5f5f5", "tonalRamp": ["#171717", "#262626", "#404040", "#525252", "#737373", "#a3a3a3", "#e5e5e5", "#fafafa"] },
+      "syntax-keyword": { "role": "tertiary", "displayName": "Syntax Keyword", "canonical": "#f47067" },
+      "syntax-string": { "role": "tertiary", "displayName": "Syntax String", "canonical": "#00a99a" }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Page and post titles." },
+      "body": { "displayName": "Body", "purpose": "Article prose at 75% ink, capped to a 640px measure." },
+      "mono": { "displayName": "Mono", "purpose": "Inline code and code blocks (Geist Mono)." }
+    },
+    "shadows": [],
+    "motion": [
+      { "name": "color-transition", "value": "color 300ms ease-in-out, background-color 300ms ease-in-out", "purpose": "Default hover/focus state transition on all interactive chrome." },
+      { "name": "reveal", "value": "transform 300ms ease-out, opacity 300ms ease-out", "purpose": "Entrance animation for .animate elements (-translate-y-3 / opacity-0 to rest)." }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Compact bordered control used for search and theme toggles. Tactile hover wash.",
+      "html": "<button class=\"ds-btn-ghost\">search</button>",
+      "css": ".ds-btn-ghost { display: inline-flex; align-items: center; gap: 4px; background: #f5f5f5; color: rgba(0,0,0,0.75); font: 400 12px/1.4 'Geist Sans', ui-sans-serif, system-ui, sans-serif; padding: 4px 8px; border: 1px solid rgba(0,0,0,0.15); border-radius: 4px; transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out; cursor: pointer; } .ds-btn-ghost:hover, .ds-btn-ghost:focus-visible { background: rgba(0,0,0,0.05); color: #000; outline: none; }"
+    },
+    {
+      "name": "Arrow Card",
+      "kind": "card",
+      "refersTo": "card-arrow",
+      "description": "Signature post/project list item. Hairline border, hover wash, self-drawing arrow.",
+      "html": "<a class=\"ds-arrow-card\" href=\"#\"><span class=\"ds-arrow-card__body\"><span class=\"ds-arrow-card__title\">Conditional complexity</span><span class=\"ds-arrow-card__desc\">Refactoring nested conditionals into readable guard clauses.</span></span><svg class=\"ds-arrow-card__icon\" viewBox=\"0 0 24 24\"><line x1=\"5\" y1=\"12\" x2=\"19\" y2=\"12\"></line><polyline points=\"12 5 19 12 12 19\"></polyline></svg></a>",
+      "css": ".ds-arrow-card { position: relative; display: flex; align-items: stretch; gap: 8px; padding: 12px 40px 12px 16px; border: 1px solid rgba(0,0,0,0.15); border-radius: 8px; color: rgba(0,0,0,0.75); text-decoration: none; transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out; } .ds-arrow-card:hover { background: rgba(0,0,0,0.05); color: #000; } .ds-arrow-card__body { display: flex; flex-direction: column; min-width: 0; } .ds-arrow-card__title { font: 600 16px/1.4 'Geist Sans', sans-serif; } .ds-arrow-card__desc { font: 400 14px/1.4 'Geist Sans', sans-serif; } .ds-arrow-card__icon { position: absolute; top: 50%; right: 8px; width: 20px; height: 20px; transform: translateY(-50%); fill: none; stroke: currentColor; stroke-width: 2; } .ds-arrow-card__icon line { transform: translateX(12px) scaleX(0); transition: transform 0.3s ease-in-out; } .ds-arrow-card:hover .ds-arrow-card__icon line { transform: translateX(0) scaleX(1); } .ds-arrow-card__icon polyline { transform: translateX(-4px); transition: transform 0.3s ease-in-out; } .ds-arrow-card:hover .ds-arrow-card__icon polyline { transform: translateX(0); }"
+    },
+    {
+      "name": "Callout (Info)",
+      "kind": "custom",
+      "refersTo": "callout-info",
+      "description": "Semantic in-prose note. Tinted background, full hairline border in the state hue, leading emoji.",
+      "html": "<div class=\"ds-callout ds-callout--info\"><span class=\"ds-callout__icon\">ℹ️</span><span>Geist Mono renders the inline <code>code</code> in technical notes.</span></div>",
+      "css": ".ds-callout { display: flex; gap: 12px; padding: 12px; border-radius: 6px; border: 1px solid; font: 400 15px/1.5 'Geist Sans', sans-serif; } .ds-callout__icon { flex: none; font-size: 20px; line-height: 1; user-select: none; } .ds-callout--info { border-color: #1e40af; background: #dbeafe; color: #172554; } .ds-callout code { font-family: 'Geist Mono', ui-monospace, monospace; }"
+    },
+    {
+      "name": "Nav Link",
+      "kind": "nav",
+      "refersTo": "nav-link",
+      "description": "Lowercase underlined navigation link with offset underline that deepens on hover.",
+      "html": "<a class=\"ds-nav-link\" href=\"#\">blog</a>",
+      "css": ".ds-nav-link { font: 400 14px/1.4 'Geist Sans', sans-serif; color: rgba(0,0,0,0.75); text-decoration: underline; text-underline-offset: 3px; text-decoration-color: rgba(0,0,0,0.3); transition: color 0.3s ease-in-out, text-decoration-color 0.3s ease-in-out; } .ds-nav-link:hover, .ds-nav-link:focus-visible { color: #000; text-decoration-color: rgba(0,0,0,0.5); outline: none; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Engineer's Notebook",
+    "overview": "A monochrome reading instrument, not a marketing site. Geist Sans carries the prose; Geist Mono carries the code. Ink on near-white paper, with no brand accent competing for attention. Color enters in exactly two places: syntax highlighting inside code blocks, and the four semantic callout tints. Everywhere else, hierarchy is built from weight, size, and space. The system is flat: depth comes from hairline borders and faint hover tints, never shadows. Interaction is tactile and confident.",
+    "keyCharacteristics": [
+      "Strictly monochrome chrome; color is reserved for code and callouts.",
+      "Flat by default — borders and tints convey depth, never shadows.",
+      "Two-weight-superfamily type system: Geist Sans + Geist Mono.",
+      "Full light/dark parity, theme-switchable (light / dark / system).",
+      "Lowercase, understated navigation; the lightning bolt is the only mark."
+    ],
+    "rules": [
+      { "name": "The Monochrome Chrome Rule", "body": "The interface is grayscale. Color appears only inside code blocks (syntax) and callouts (semantics). A colored button, heading, or brand accent in the chrome is forbidden.", "section": "colors" },
+      { "name": "The Lowercase Nav Rule", "body": "Primary navigation and small UI labels stay lowercase. A deliberate, understated voice signal. Don't title-case or uppercase them.", "section": "typography" },
+      { "name": "The No-Shadow Rule", "body": "Surfaces never lift with box-shadow. Use a hairline border or one-step surface tint. State is shown with a background wash and color shift, never elevation.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do keep the chrome strictly monochrome — color belongs to code and callouts only.",
+      "Do build depth from hairline borders and one-step surface tints, never shadows.",
+      "Do maintain full light/dark parity, contrast-checked to WCAG AA.",
+      "Do keep navigation and small labels lowercase.",
+      "Do use Geist Sans for prose and Geist Mono for code; lean on weight and size for hierarchy.",
+      "Do give every animation a prefers-reduced-motion path and gate reveals on a visible default.",
+      "Do cap body measure with the 640px container."
+    ],
+    "donts": [
+      "Don't introduce a brand accent color, gradient, or background-clip: text in the chrome.",
+      "Don't use drop shadows or decorative glassmorphism (the header blur is the one exception).",
+      "Don't ship the generic SaaS/template blog look: no hero-metric cards, no identical card grids.",
+      "Don't drift corporate/cold or over-designed/flashy.",
+      "Don't clutter the page with ad rails, popups, or competing widgets.",
+      "Don't nest cards or use a border-left color stripe as an accent.",
+      "Don't title-case or uppercase the navigation; don't set body copy in all caps."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["src/layouts/Layout.astro"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+Package manager is **Bun**. Astro 6 + Tailwind v4.
+
+- `bun run dev` — dev server at `http://localhost:4321`.
+- `bun run build` — `astro check` (type check) then `astro build`. Forces Pagefind to index in English (`PAGEFIND_FORCE_LANGUAGE=en`).
+- `bun run preview` — serve the production build locally.
+- `bun run lint` / `bun run lint:fix` — ESLint over the repo (also lints JSON and Markdown).
+- `bun run test` — Playwright E2E suite. **Non-CI runs build + preview first** (`webServer.command` = `bun run build && bun run preview`), so a clean run is slow; the server is reused if already up.
+- Single test file: `bunx playwright test test/home.spec.ts`. By title: `bunx playwright test -g "renders the hero"`. Debug UI: `bun run test:ui`.
+
+Tests live in `test/` (not `src`). In CI they hit `BASE_URL`; locally they hit `http://localhost:4321/`.
+
+## Architecture
+
+Content-driven personal blog + portfolio built on the **astro-micro** theme. Static output, deployed to **Vercel** (`outputDirectory: dist`).
+
+**Content collections** ([src/content.config.ts](src/content.config.ts)) are the data layer. Two glob collections, `blog` and `projects`, load Markdown/MDX from `src/content/<collection>/<slug>/index.md(x)`. Each entry is a folder so co-located images ship with the post. Zod schemas enforce frontmatter (`title`, `description`, `date`, optional `draft`, `tags`/`demoURL`/`repoURL`). Adding a post = adding a folder; routes generate automatically.
+
+**Routing** is file-based in [src/pages/](src/pages/). Dynamic routes `blog/[...id].astro` and `projects/[...id].astro` use `getStaticPaths` over the collections; `tags/[id].astro` generates a page per tag. `rss.xml.js` and the sitemap integration derive from the same collections — collections are the single source of truth for content.
+
+**Bilingual (ES/EN).** Site content is primarily Spanish; UI/metadata is bilingual. [src/consts.ts](src/consts.ts) centralizes site/author/socials/work-experience and carries `*_ES` fields (e.g. `BIO_ES`, `JOB_TITLE_ES`). `lang` flows from page → `Layout` → `Head`, where it sets `<html lang>` and the OG locale. Edit `consts.ts` for site-wide text, not individual components.
+
+**Layout chain.** [src/layouts/Layout.astro](src/layouts/Layout.astro) is the only layout: it renders `Head` (global CSS import, fonts, `ClientRouter` view transitions, OG/meta), `Header`, `<slot/>`, `Footer`, and the Pagefind search modal. The `Container` component (`max-w-(--breakpoint-sm)`, 640px) sets the reading measure everywhere.
+
+**Styling.** Tailwind v4 via the Vite plugin — **no `tailwind.config`**; theme tokens live in `@theme` inside [src/styles/global.css](src/styles/global.css), which also holds base element styles, the `.animate` reveal classes, and the Prism syntax-highlighting token palette (light + dark). Dark mode is class-based (`.dark` on `<html>`), driven by [src/scripts/theme.ts](src/scripts/theme.ts) (light/dark/system, persisted). The `@components`/`@consts`/`@types` import aliases resolve to `src/*` via the `@*` tsconfig path.
+
+**Fonts & CSP.** Fonts use Astro's experimental `fonts` API ([astro.config.mjs](astro.config.mjs)): Geist Sans (`--font-blog`, fontsource) and Geist Mono (`--font-code`, google), exposed as Tailwind `--font-sans`/`--font-mono`. The same config defines a **build-time Content Security Policy** (`security.csp`) — when adding external scripts/frames/images (e.g. another embed like Giscus), update those directives or the built pages will block them. Security headers are duplicated in [public/_headers](public/_headers) and [vercel.json](vercel.json).
+
+**Client scripts** ([src/scripts/](src/scripts/)) are small vanilla-TS enhancements wired up through view transitions: `animate.ts` (scroll reveal), `scroll.ts`, `copy-code.ts`, `theme.ts`, `giscus.ts` (comments), `pagefind.ts` (search). Reveal animations have a `<noscript>` fallback in `Layout.astro` so content is visible without JS.
+
+**OG images** are generated at build by `astro-opengraph-images` using [src/components/OgImage.tsx](src/components/OgImage.tsx) (the repo's only React/JSX, hence the `react`/`@types/react` dev deps).
+
+## Design Context
+
+Before any UI/design task, read [PRODUCT.md](PRODUCT.md) (strategic: register, users, voice, anti-references) and [DESIGN.md](DESIGN.md) (visual system). Register is **brand** (personal blog/portfolio — design IS the product). These power the impeccable design skill; `/impeccable` lists its commands, `/impeccable live` is pre-configured.
+
+Visual identity to preserve:
+- **Monochrome chrome.** Grayscale `neutral-100`/`neutral-900` surfaces, `black`/`white` ink at 75% for body. Color is reserved for code syntax and the four semantic callouts — never a brand accent in the chrome.
+- **Flat, no shadows.** Depth comes from hairline borders (`black/15`, `white/20`) and hover tints (`black/5`, `white/5`).
+- **Geist Sans (prose) + Geist Mono (code)**, weights 400/500/600.
+- **Full light/dark parity**, WCAG AA; lowercase navigation as a voice signal.
+
+## Conventions
+
+- Commits follow Conventional Commits (`feat:`, `fix:`, `build(deps):`, …); attribution is disabled.
+- Dependency bumps are automated via Dependabot with auto-merge; most history is dep PRs.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,180 @@
+---
+name: Fausto Moya
+description: Personal blog and portfolio — a monochrome reading room for Spanish-language software writing.
+colors:
+  ink-light: "#000000"
+  ink-dark: "#fafafa"
+  surface-light: "#f5f5f5"
+  surface-dark: "#171717"
+  code-surface-light: "#fafafa"
+  code-surface-dark: "#09090b"
+  syntax-keyword: "#f47067"
+  syntax-string: "#00a99a"
+  syntax-function: "#429996"
+  syntax-number: "#2b70c5"
+  syntax-regex: "#ae42a0"
+  syntax-url: "#8d85ff"
+  syntax-punctuation: "#8996a3"
+  syntax-comment: "#a19595"
+typography:
+  display:
+    fontFamily: "Geist Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "clamp(1.875rem, 5vw, 2.25rem)"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "-0.01em"
+  headline:
+    fontFamily: "Geist Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 600
+    lineHeight: 1.3
+  body:
+    fontFamily: "Geist Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.6
+  label:
+    fontFamily: "Geist Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.4
+  mono:
+    fontFamily: "Geist Mono, ui-monospace, SFMono-Regular, Menlo, monospace"
+    fontSize: "0.9em"
+    fontWeight: 400
+    lineHeight: 1.6
+rounded:
+  sm: "4px"
+  md: "6px"
+  lg: "8px"
+spacing:
+  page-x: "12px"
+  block: "24px"
+  section: "128px"
+  max-width: "640px"
+components:
+  button-ghost:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.ink-light}"
+    rounded: "{rounded.sm}"
+    padding: "4px 8px"
+  card-arrow:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.ink-light}"
+    rounded: "{rounded.lg}"
+    padding: "12px 16px"
+  callout-info:
+    backgroundColor: "#dbeafe"
+    textColor: "#172554"
+    rounded: "{rounded.md}"
+    padding: "12px"
+---
+
+# Design System: Fausto Moya
+
+## 1. Overview
+
+**Creative North Star: "The Engineer's Notebook"**
+
+This is a monochrome reading instrument, not a marketing site. Geist Sans carries the prose; Geist Mono carries the code. The page is ink on near-white paper (and near-white ink on near-black paper in dark mode), with no brand accent color competing for attention. Color enters in exactly two places: the syntax highlighting inside code blocks, and the four semantic callout tints. Everywhere else, hierarchy is built from weight, size, and space, the way a well-set technical book is.
+
+The system is **flat**. There are no drop shadows. Depth comes from hairline borders (`black/15`, `white/20`) and faint hover tints (`black/5`, `white/5`), never from elevation. The single atmospheric flourish is the header: a translucent `neutral-100/75` bar with `backdrop-blur-xs` and `saturate-200`, so content scrolls softly behind it. Interaction is **tactile and confident**: controls have real borders and visible hover/focus states, arrows slide and scale on hover, the theme toggles pulse. Restraint is the resting state, not the only state.
+
+It explicitly rejects the generic SaaS/template blog (no hero-metric cards, no identical icon-heading-text grids), the corporate/cold stock-photo aesthetic, the over-designed/flashy gradient-and-glass look, and the cluttered ad-rail-and-widget pileup. The writing leads; the design defends the read.
+
+**Key Characteristics:**
+- Strictly monochrome chrome; color is reserved for code and callouts.
+- Flat by default — borders and tints convey depth, never shadows.
+- Two-weight-superfamily type system: Geist Sans + Geist Mono.
+- Full light/dark parity, theme-switchable (light / dark / system).
+- Lowercase, understated navigation; the lightning bolt (⚡️) is the only mark.
+
+## 2. Colors
+
+A monochrome neutral system with two reserved color vocabularies: syntax highlighting and semantic callouts.
+
+### Primary
+- **Ink** (`#000000` light / `#fafafa` dark): Headings render at full ink; body text at 75% opacity (`black/75`, `white/75`) for comfortable long-form reading. Links inherit `currentColor` and resolve to full ink on hover.
+
+### Neutral
+- **Paper** (`#f5f5f5` `neutral-100` light / `#171717` `neutral-900` dark): The page surface. Calm, slightly off-pure to reduce glare.
+- **Code Paper** (`#fafafa` light / `#09090b` dark): Code-block surfaces, set one step apart from the page so listings read as inset panels.
+- **Hairline Border** (`black/15` light / `white/20` dark): Every border on the site. One token, used everywhere.
+- **Hover Wash** (`black/5` light / `white/5` dark): The faint tint on interactive surfaces at hover/focus.
+
+### Tertiary — Syntax Palette
+Reserved exclusively for code tokens; never used as UI color.
+- **Keyword** (`#f47067`), **String** (`#00a99a`), **Function / Class** (`#429996`), **Number / Constant** (`#2b70c5`), **Regex** (`#ae42a0`), **URL** (`#8d85ff`), **Punctuation** (`#8996a3`), **Comment** (`#a19595`). Dark mode shifts functions/numbers/regex to lighter tints for contrast.
+
+### Tertiary — Callout Semantics
+Four states, each a Tailwind 100/800/950 triad: **Default/Tip** (orange), **Info** (blue), **Warning** (yellow), **Error** (red). Used only inside `<Callout>` blocks within prose.
+
+### Named Rules
+**The Monochrome Chrome Rule.** The interface is grayscale. Color appears only inside code blocks (syntax) and callouts (semantics). A colored button, a colored heading, or a brand accent anywhere in the chrome is forbidden — it breaks the reading-room contract.
+
+## 3. Typography
+
+**Display / Body Font:** Geist Sans (with `ui-sans-serif, system-ui, sans-serif`)
+**Code / Mono Font:** Geist Mono (with `ui-monospace, SFMono-Regular, Menlo, monospace`)
+
+**Character:** One geometric superfamily in two voices. Geist Sans is clean, neutral, and Dutch-modern — it gets out of the way of the prose. Geist Mono handles code and the occasional technical label. Weights are limited to 400 / 500 / 600; there is no light or heavy extreme. The contrast in the system is sans-vs-mono and weight-vs-size, not serif-vs-sans.
+
+### Hierarchy
+- **Display** (600, `clamp(1.875rem, 5vw, 2.25rem)`, lh 1.2): Page and post titles. Set with `text-wrap: balance`.
+- **Headline** (600, ~1.5rem, lh 1.3): In-article `h2`/`h3`, via `@tailwindcss/typography` `prose`.
+- **Body** (400, 1rem, lh ~1.6): Article prose at `black/75`. Capped to a comfortable measure by the 640px container.
+- **Label** (400, 0.875rem / 0.75rem): Navigation, metadata, dates, button text. Lowercase by authorial choice (`blog / experience / projects`).
+- **Mono** (400, ~0.9em): Inline code and code blocks in Geist Mono.
+
+### Named Rules
+**The Lowercase Nav Rule.** Primary navigation and small UI labels stay lowercase. It is a deliberate voice signal — understated, personal, not corporate. Don't title-case or uppercase them.
+
+## 4. Elevation
+
+This system is **flat by default**. There are no drop shadows anywhere. Depth and separation are conveyed by hairline borders (`black/15`, `white/20`), one-step surface shifts (page vs. code panel), and faint hover washes. The only blur in the system is the header's `backdrop-blur-xs` + `saturate-200`, which is atmospheric, not elevational.
+
+### Named Rules
+**The No-Shadow Rule.** Surfaces never lift with `box-shadow`. If something needs to feel distinct, give it a hairline border or a one-step surface tint, not a shadow. State (hover, focus) is shown with a background wash and color shift, never elevation.
+
+## 5. Components
+
+Components are **tactile and confident**: real borders, visible hover/focus states, and short directional motion. All transitions are `300ms ease-in-out` on color, or `ease-out` on the entrance animation.
+
+### Buttons
+- **Shape:** Small radius (`rounded-sm`, 4px). Square-ish, compact.
+- **Ghost (search, theme toggles):** Transparent/`neutral` background, hairline border (`black/15` / `white/20`), `text-xs`/`size-9`. Hover and `focus-visible` add a `black/5` wash and shift text/stroke to full ink. Theme-toggle icons `animate-pulse` on hover.
+- **Back-to-top:** Same ghost treatment; an arrow slides in (`translate-x` + `scale-x`) on hover. Reveals on scroll via a `.scrolled` class on `html`.
+
+### Cards
+- **Arrow Card (post/project list item):** `rounded-lg` (8px), hairline border, `px-4 py-3`. `not-prose`. Title at `font-semibold`, description at `text-sm`. On hover: `black/5` wash, text to full ink, and a right-pointing arrow draws itself in (line scales from 0, chevron slides). The signature interactive component of the site.
+- **No nested cards. No shadow.** Separation is the border alone.
+
+### Callouts
+- **Style:** `rounded` (md), full hairline border in the state hue, tinted background, matching text color. Leading emoji (💡 ℹ️ ⚠️ 🚨) in the gutter, `not-prose`.
+- **States:** default (orange), info (blue), warning (yellow), error (red).
+
+### Navigation
+- **Style:** Lowercase `text-sm` links separated by literal `/` glyphs. Underline links use `underline-offset-[3px]` with `decoration-*/30`, deepening to `/50` on hover. The header is a fixed, translucent, blurred bar; `transition:persist` across view transitions.
+
+### Code Block (signature)
+- Inset panel on `code-surface`, hairline border, `py-5`. A `copy-code` ghost button (`size-9`, `rounded-sm`) sits top-right, scales to 90% on `:active`. Syntax via the reserved syntax palette.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** keep the chrome strictly monochrome — color belongs to code and callouts only (The Monochrome Chrome Rule).
+- **Do** build depth from hairline borders (`black/15` / `white/20`) and one-step surface tints, never shadows.
+- **Do** maintain full light/dark parity — every new surface, border, and text color needs both variants, contrast-checked to WCAG AA.
+- **Do** keep navigation and small labels lowercase (The Lowercase Nav Rule).
+- **Do** use Geist Sans for prose and Geist Mono for code/technical labels; lean on weight (400/500/600) and size for hierarchy.
+- **Do** give every animation a `prefers-reduced-motion: reduce` path, and gate reveal animations on a visible default (the `<noscript>` fallback already does this for `.animate`).
+- **Do** cap body measure with the 640px container for a comfortable reading line.
+
+### Don't:
+- **Don't** introduce a brand accent color, gradient, or `background-clip: text` anywhere in the chrome.
+- **Don't** use drop shadows or decorative glassmorphism (the header blur is the one sanctioned, atmospheric exception).
+- **Don't** ship the generic SaaS/template blog look: no hero-metric cards, no identical icon-heading-text card grids.
+- **Don't** drift corporate/cold or over-designed/flashy; no stock-photo business aesthetic, no gratuitous animation.
+- **Don't** clutter the page with ad rails, popups, or competing widgets — the writing leads.
+- **Don't** nest cards, or use a `border-left` color stripe as an accent; use the full hairline border.
+- **Don't** title-case or uppercase the navigation; don't set body copy in all caps.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,39 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Spanish-speaking software developers, from juniors leveling up to seasoned engineers. They arrive from search, social, or a shared link looking to read a focused article on clean code, refactoring, code smells, testing, or software craft, in their own language. Secondary audience: recruiters and peers checking the portfolio (experience, projects) to gauge who Fausto Moya is. Context is a reading session, often on mobile, often skimming before committing to read.
+
+## Product Purpose
+
+Fausto Moya's personal blog and portfolio. It exists to publish in-depth, opinionated technical writing for the Spanish-speaking developer community (a niche underserved by quality long-form content) and to present Fausto's professional identity (experience, projects) in one place. Success: a reader trusts the writing, reads to the end, returns for the next post, and leaves seeing a credible, thoughtful engineer.
+
+## Brand Personality
+
+Precise, technical, and opinionated, with a warm, mentoring undertone. The voice teaches without condescending: confident takes on craft, delivered generously to help others level up. Visually calm, minimal, and content-first; the design gets out of the way of the prose. Three words: **precise, warm, focused.**
+
+## Anti-references
+
+- **Generic SaaS / template blog.** No cookie-cutter Medium/Hashnode look, no hero-metric cards, no identical icon-heading-text card grids.
+- **Corporate / cold.** No stiff enterprise tone, no stock-photo business aesthetic.
+- **Over-designed / flashy.** No gratuitous animation, no gradients-everywhere, no decoration that fights readability.
+- **Cluttered / busy.** No ad rails, popups, or widget pileups competing with the content.
+
+## Design Principles
+
+1. **Content is the interface.** Typography and reading comfort are the product. Every visual decision defends the reading experience first.
+2. **Restraint with intent, not by default.** Minimal because the writing leads, not because minimal is safe. Where a moment of craft earns its place, take it.
+3. **Practice what you preach.** A blog about clean code and craft must itself be clean, accessible, fast, and well-built. The site is a portfolio artifact.
+4. **Bilingual by nature.** Spanish content is first-class; the system handles ES/EN copy and metadata without feeling bolted on.
+5. **Teach generously.** Clarity over cleverness in copy, navigation, and structure, mirroring the mentoring voice.
+
+## Accessibility & Inclusion
+
+- **WCAG 2.2 AA** contrast for body and large text in both themes; verify muted text, code tokens, and link states.
+- **Dark / light parity:** both themes fully tested for legibility and contrast, not one as an afterthought.
+- **Reduced motion:** every animation (entrance reveals, scroll, back-to-top) needs a `prefers-reduced-motion: reduce` alternative.
+- **Keyboard + screen reader:** full keyboard navigation, semantic landmarks, meaningful link and alt text, visible focus states.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,9 +5,38 @@ import pagefind from "astro-pagefind";
 import { defineConfig, fontProviders } from "astro/config";
 import fs from "node:fs";
 
-import opengraphImages from "astro-opengraph-images";
-import { ogImage } from "./src/components/OgImage";
 import rehypePrismPlus from "rehype-prism-plus";
+
+// OG images are build-time social-card artifacts (never rendered in the page UI).
+// astro-opengraph-images pulls in @resvg/resvg-js, a native CJS addon that throws
+// "require is not defined" under Astro's dev/SSR ESM module runner. Importing it
+// statically evaluates resvg at config-load time even in dev, so load it lazily
+// and only for `astro build`. `getImagePath` (in Head.astro) is a pure path helper
+// with no resvg dependency, so og:image meta tags still resolve in dev.
+const isBuild = process.argv.includes("build");
+const ogImagesIntegration = isBuild
+  ? await (async () => {
+      const { default: opengraphImages } = await import(
+        "astro-opengraph-images"
+      );
+      const { ogImage } = await import("./src/components/OgImage");
+      return opengraphImages({
+        options: {
+          fonts: [
+            {
+              name: "Geist Sans",
+              weight: 400,
+              style: "normal",
+              data: fs.readFileSync(
+                "node_modules/@fontsource/geist-sans/files/geist-sans-latin-400-normal.woff",
+              ),
+            },
+          ],
+        },
+        render: ogImage,
+      });
+    })()
+  : null;
 
 // https://astro.build/config
 export default defineConfig({
@@ -19,22 +48,15 @@ export default defineConfig({
   integrations: [
     sitemap(),
     mdx(),
-    pagefind(),
-    opengraphImages({
-      options: {
-        fonts: [
-          {
-            name: "Geist Sans",
-            weight: 400,
-            style: "normal",
-            data: fs.readFileSync(
-              "node_modules/@fontsource/geist-sans/files/geist-sans-latin-400-normal.woff",
-            ),
-          },
-        ],
-      },
-      render: ogImage,
-    }),
+    // Force a single Spanish index. The site is bilingual (en home/projects/
+    // experience, es blog/tags), so by default pagefind builds separate per-lang
+    // indexes and the search UI only queries the one matching the current page's
+    // <html lang> -- hiding every Spanish blog post from search opened on an en
+    // page. `forceLanguage` indexes the whole site as one (es) index. The Node API
+    // used by this integration ignores PAGEFIND_FORCE_LANGUAGE, so it must be set
+    // here, not via env var.
+    pagefind({ indexConfig: { forceLanguage: "es" } }),
+    ...(ogImagesIntegration ? [ogImagesIntegration] : []),
   ],
   vite: {
     plugins: [tailwindcss()],
@@ -66,7 +88,10 @@ export default defineConfig({
         "connect-src 'self'",
       ],
       scriptDirective: {
-        resources: ["'self'", "https://giscus.app"],
+        // 'wasm-unsafe-eval' lets Pagefind compile its search-index WebAssembly.
+        // It is the narrow WASM token (not general 'unsafe-eval'): it permits
+        // WebAssembly.instantiate only, no eval()/new Function() on JS strings.
+        resources: ["'self'", "'wasm-unsafe-eval'", "https://giscus.app"],
       },
       styleDirective: {
         resources: ["'self'", "'unsafe-inline'"],

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "PAGEFIND_FORCE_LANGUAGE=en astro check && astro build",
+    "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "test": "playwright test",

--- a/src/components/ArrowCard.astro
+++ b/src/components/ArrowCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import ArrowIcon from "@components/ArrowIcon.astro";
 
 type Props = {
   entry: CollectionEntry<"blog"> | CollectionEntry<"projects">;
@@ -11,32 +12,16 @@ const { entry } = Astro.props as {
 ---
 
 <a
-  href={`/${entry.collection}/${entry.id}`}
-  class="not-prose group relative flex flex-nowrap rounded-lg border border-black/15 px-4 py-3 pr-10 transition-colors duration-300 ease-in-out hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black dark:border-white/20 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white"
+  href={`/${entry.collection}/${entry.id}/`}
+  class="not-prose group relative flex flex-nowrap rounded-lg px-4 py-3 pr-10 ghost-surface"
 >
-  <div class="flex flex-1 flex-col truncate">
-    <div class="font-semibold">
+  <div class="flex min-w-0 flex-1 flex-col">
+    <div class="truncate font-semibold">
       {entry.data.title}
     </div>
-    <div class="text-sm">
+    <div class="truncate text-sm">
       {entry.data.description}
     </div>
   </div>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    class="absolute top-1/2 right-2 size-5 -translate-y-1/2 fill-none stroke-current stroke-2"
-  >
-    <line
-      x1="5"
-      y1="12"
-      x2="19"
-      y2="12"
-      class="translate-x-3 scale-x-0 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-hover:scale-x-100 group-focus-visible:translate-x-0 group-focus-visible:scale-x-100"
-    ></line>
-    <polyline
-      points="12 5 19 12 12 19"
-      class="-translate-x-1 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-focus-visible:translate-x-0"
-    ></polyline>
-  </svg>
+  <ArrowIcon direction="right" size={5} />
 </a>

--- a/src/components/ArrowIcon.astro
+++ b/src/components/ArrowIcon.astro
@@ -1,0 +1,48 @@
+---
+/*
+  Animated directional arrow. The horizontal line draws itself in (scale-x)
+  and the chevron slides home on the parent's `group-hover` / `group-focus-visible`.
+  The parent must be `group relative`; the icon positions itself absolutely.
+*/
+type Props = {
+  direction?: "right" | "left" | "up";
+  size?: 4 | 5;
+};
+
+const { direction = "right", size = 5 } = Astro.props;
+
+const isRight = direction === "right";
+const sizeClass = size === 5 ? "size-5" : "size-4";
+const lineTranslate = size === 5 ? "translate-x-3" : "translate-x-2";
+const posClass = isRight ? "right-2" : "left-2";
+const rotateClass = direction === "up" ? "rotate-90" : "";
+const chevronTranslate = isRight ? "-translate-x-1" : "translate-x-1";
+const points = isRight ? "12 5 19 12 12 19" : "12 5 5 12 12 19";
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  class:list={[
+    "absolute top-1/2 -translate-y-1/2 fill-none stroke-current stroke-2",
+    posClass,
+    sizeClass,
+    rotateClass,
+  ]}
+>
+  <line
+    x1="5"
+    y1="12"
+    x2="19"
+    y2="12"
+    class:list={[
+      lineTranslate,
+      "scale-x-0 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-hover:scale-x-100 group-focus-visible:translate-x-0 group-focus-visible:scale-x-100",
+    ]}></line>
+  <polyline
+    points={points}
+    class:list={[
+      chevronTranslate,
+      "transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-focus-visible:translate-x-0",
+    ]}></polyline>
+</svg>

--- a/src/components/BackToPrevious.astro
+++ b/src/components/BackToPrevious.astro
@@ -1,4 +1,6 @@
 ---
+import ArrowIcon from "@components/ArrowIcon.astro";
+
 type Props = {
   href: string;
 };
@@ -8,25 +10,9 @@ const { href } = Astro.props;
 
 <a
   href={href}
-  class="not-prose group relative flex w-fit flex-nowrap rounded-sm border border-black/15 py-1.5 pr-3 pl-7 transition-colors duration-300 ease-in-out hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black dark:border-white/20 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white"
+  class="not-prose group relative flex min-h-11 w-fit flex-nowrap items-center rounded-sm py-1.5 pr-3 pl-7 ghost-surface"
 >
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    class="absolute top-1/2 left-2 size-4 -translate-y-1/2 fill-none stroke-current stroke-2"
-  >
-    <line
-      x1="5"
-      y1="12"
-      x2="19"
-      y2="12"
-      class="translate-x-2 scale-x-0 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-hover:scale-x-100 group-focus-visible:translate-x-0 group-focus-visible:scale-x-100"
-    ></line>
-    <polyline
-      points="12 5 5 12 12 19"
-      class="translate-x-1 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-focus-visible:translate-x-0"
-    ></polyline>
-  </svg>
+  <ArrowIcon direction="left" size={4} />
   <div class="text-sm">
     <slot />
   </div>

--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -1,40 +1,23 @@
 ---
-
+import ArrowIcon from "@components/ArrowIcon.astro";
 ---
 
 <script>
-  if (typeof window !== "undefined") {
-    window.addEventListener("DOMContentLoaded", () => {
-      const btn = document.getElementById("back-to-top");
-      if (btn) {
-        btn.addEventListener("click", () => {
-          window.scrollTo({ top: 0, behavior: "smooth" });
-        });
-      }
+  // `astro:page-load` fires on the initial load and after every view-transition
+  // swap; the button's DOM element is replaced on each navigation, so re-query
+  // and re-attach the listener each time.
+  document.addEventListener("astro:page-load", () => {
+    const btn = document.getElementById("back-to-top");
+    btn?.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
     });
-  }
+  });
 </script>
 
 <button
   id="back-to-top"
-  class="group relative flex w-fit flex-nowrap rounded-sm border border-black/15 py-1.5 pr-3 pl-8 transition-colors duration-300 ease-in-out hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black dark:border-white/20 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white"
+  class="group relative flex min-h-11 w-fit flex-nowrap items-center rounded-sm py-1.5 pr-3 pl-8 ghost-surface"
 >
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    class="absolute top-1/2 left-2 size-4 -translate-y-1/2 rotate-90 fill-none stroke-current stroke-2"
-  >
-    <line
-      x1="5"
-      y1="12"
-      x2="19"
-      y2="12"
-      class="translate-x-2 scale-x-0 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-hover:scale-x-100 group-focus-visible:translate-x-0 group-focus-visible:scale-x-100"
-    ></line>
-    <polyline
-      points="12 5 5 12 12 19"
-      class="translate-x-1 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-focus-visible:translate-x-0"
-    ></polyline>
-  </svg>
+  <ArrowIcon direction="up" size={4} />
   <div class="text-sm">Back to top</div>
 </button>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,7 +17,7 @@ import BackToTop from "@components/BackToTop.astro";
         <button
           id="light-theme-button"
           aria-label="Light theme"
-          class="group flex size-9 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+          class="group flex size-11 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -45,7 +45,7 @@ import BackToTop from "@components/BackToTop.astro";
         <button
           id="dark-theme-button"
           aria-label="Dark theme"
-          class="group flex size-9 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+          class="group flex size-11 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -65,7 +65,7 @@ import BackToTop from "@components/BackToTop.astro";
         <button
           id="system-theme-button"
           aria-label="System theme"
-          class="group flex size-9 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+          class="group flex size-11 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -1,14 +1,16 @@
 ---
 interface Props {
   date: Date;
+  lang?: "en" | "es";
 }
 
-const { date } = Astro.props;
+const { date, lang = "en" } = Astro.props;
+const locale = lang === "es" ? "es-ES" : "en-US";
 ---
 
 <time datetime={date.toISOString()}>
   {
-    date.toLocaleDateString("en-US", {
+    date.toLocaleDateString(locale, {
       month: "long",
       day: "2-digit",
       year: "numeric",

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -2,7 +2,7 @@
 import "../styles/global.css";
 import { ClientRouter } from "astro:transitions";
 import { Font } from "astro:assets";
-import { getImagePath } from "astro-opengraph-images";
+import { getImagePath } from "@utils";
 
 interface Props {
   title: string;
@@ -52,16 +52,22 @@ const image = getImagePath({ url, site });
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
 
-<!-- PageFind -->
-<link href="/pagefind/pagefind-ui.css" rel="stylesheet" />
-<script is:inline src="/pagefind/pagefind-ui.js" defer></script>
+<!-- Pagefind UI (CSS + JS, ~26KB) is lazy-loaded on first search-open in
+     scripts/pagefind.ts, not eagerly here: the search modal is opened rarely,
+     so every page no longer pays for it on initial load. -->
 <ClientRouter />
 <Font cssVariable="--font-blog" preload />
-<Font cssVariable="--font-code" preload />
+<!-- Geist Mono is only painted in code blocks (article pages, below the fold).
+     Emit its @font-face but don't preload it: preloading pulled ~70KB of mono
+     onto every code-less page (home, experience, projects, tags), competing with
+     the critical Sans font for LCP. Without preload the browser fetches it only
+     when a code block actually renders. -->
+<Font cssVariable="--font-code" />
 
 <!-- FOUC prevention: set dark class before first paint and on View Transition swaps -->
 <script is:inline>
   (function () {
+    document.documentElement.classList.add("js");
     function getThemePreference() {
       var theme = localStorage.getItem("theme");
       var prefersDark = window.matchMedia(

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,23 +12,23 @@ import { SITE } from "@consts";
           {SITE.TITLE}⚡️
         </div>
       </Link>
-      <nav class="flex items-center gap-1 text-sm">
-        <Link href="/blog">blog</Link>
+      <nav class="flex items-center gap-1 text-sm [&_a]:py-2">
+        <Link href="/blog/">blog</Link>
         <span>
           {`/`}
         </span>
-        <Link href="/experience">experience</Link>
+        <Link href="/experience/">experience</Link>
         <span>
           {`/`}
         </span>
-        <Link href="/projects">projects</Link>
+        <Link href="/projects/">projects</Link>
         <span>
           {`/`}
         </span>
         <button
           id="magnifying-glass"
           aria-label="Search"
-          class="flex items-center rounded-sm border border-black/15 bg-neutral-100 px-2 py-1 text-xs transition-colors duration-300 ease-in-out hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black dark:border-white/20 dark:bg-neutral-900 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white"
+          class="flex items-center rounded-sm bg-neutral-100 px-2 py-1.5 text-xs ghost-surface dark:bg-neutral-900"
         >
           search
           <svg

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -18,6 +18,7 @@ const {
 <a
   href={href}
   target={external ? "_blank" : "_self"}
+  rel={external ? "noopener noreferrer" : undefined}
   class:list={[
     "inline-block decoration-black/30 dark:decoration-white/30 hover:decoration-black/50 focus-visible:decoration-black/50 dark:hover:decoration-white/50 dark:focus-visible:decoration-white/50 text-current hover:text-black focus-visible:text-black dark:hover:text-white dark:focus-visible:text-white transition-colors duration-300 ease-in-out",
     underline && "underline underline-offset-[3px]",

--- a/src/components/PageFind.astro
+++ b/src/components/PageFind.astro
@@ -1,34 +1,23 @@
 ---
-import Search from "astro-pagefind/components/Search";
+// The Pagefind UI is initialized lazily in scripts/pagefind.ts on first open.
+// We render a bare mount node instead of astro-pagefind's <Search> component so
+// its bundled copy of @pagefind/default-ui (~23KB) never ships on page load.
 ---
 
-<aside data-pagefind-ignore>
-  <div
-    transition:persist
-    id="backdrop"
-    class="bg-[rgba(0, 0, 0, 0.5] invisible fixed top-0 left-0 z-50 flex h-screen w-full justify-center p-6 backdrop-blur-xs"
-  >
-    <div
-      id="pagefind-container"
-      class="m-0 flex h-fit max-h-[80%] w-full max-w-(--breakpoint-sm) flex-col overflow-auto rounded-sm border border-black/15 bg-neutral-100 p-2 px-4 py-3 shadow-lg dark:border-white/20 dark:bg-neutral-900"
-    >
-      <Search
-        id="search"
-        className="pagefind-ui"
-        uiOptions={{
-          showImages: false,
-          excerptLength: 15,
-          resetStyles: false,
-        }}
-      />
-      <div class="dark:prose-invert mr-2 pt-4 pb-1 text-right text-xs">
-        Press <span class="prose dark:prose-invert text-xs"
-          ><kbd class="">Esc</kbd></span
-        > or click anywhere to close
-      </div>
-    </div>
+<dialog
+  transition:persist
+  id="pagefind-dialog"
+  aria-label="Search"
+  data-pagefind-ignore
+  class="mx-auto mt-[10vh] mb-0 hidden h-fit max-h-[80%] w-full max-w-(--breakpoint-sm) flex-col overflow-auto rounded-sm border border-black/15 bg-neutral-100 p-2 px-4 py-3 open:flex dark:border-white/20 dark:bg-neutral-900"
+>
+  <div id="search" class="pagefind-ui"></div>
+  <div class="dark:prose-invert mr-2 pt-4 pb-1 text-right text-xs">
+    Press <span class="prose dark:prose-invert text-xs"
+      ><kbd class="">Esc</kbd></span
+    > or click anywhere to close
   </div>
-</aside>
+</dialog>
 
 <script>
   import { init as initPagefind } from "../scripts/pagefind";
@@ -38,7 +27,10 @@ import Search from "astro-pagefind/components/Search";
 </script>
 
 <style is:global>
-  :root {
+  /* Scope the var overrides to the dialog (ID specificity) so they win over
+     pagefind-ui.css's own `:root` defaults, which now load at runtime (lazy
+     init) and would otherwise override an equal-specificity `:root`/`.dark`. */
+  #pagefind-dialog {
     --pagefind-ui-scale: 0.75;
     --pagefind-ui-border-width: 1px;
     --pagefind-ui-border-radius: 3px;
@@ -50,11 +42,16 @@ import Search from "astro-pagefind/components/Search";
     --pagefind-ui-tag: #f5f5f5;
   }
 
-  .dark {
+  .dark #pagefind-dialog {
     --pagefind-ui-primary: #d4d4d4;
     --pagefind-ui-text: #d4d4d4;
     --pagefind-ui-background: #171717;
     --pagefind-ui-border: #404040;
+  }
+
+  #pagefind-dialog::backdrop {
+    background-color: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(4px);
   }
 
   #search input {

--- a/src/components/PostNavigation.astro
+++ b/src/components/PostNavigation.astro
@@ -1,4 +1,6 @@
 ---
+import ArrowIcon from "@components/ArrowIcon.astro";
+
 const { prevPost, nextPost } = Astro.props;
 ---
 
@@ -6,27 +8,11 @@ const { prevPost, nextPost } = Astro.props;
   {
     prevPost?.id ? (
       <a
-        href={`/blog/${prevPost?.id}`}
-        class="group relative flex flex-nowrap rounded-lg border border-black/15 px-4 py-3 pl-10 no-underline transition-colors duration-300 ease-in-out hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black dark:border-white/20 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white"
+        href={`/blog/${prevPost?.id}/`}
+        class="group relative flex min-w-0 flex-nowrap rounded-lg px-4 py-3 pl-10 no-underline ghost-surface"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          class="absolute top-1/2 left-2 size-5 -translate-y-1/2 fill-none stroke-current stroke-2"
-        >
-          <line
-            x1="5"
-            y1="12"
-            x2="19"
-            y2="12"
-            class="translate-x-3 scale-x-0 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-hover:scale-x-100 group-focus-visible:translate-x-0 group-focus-visible:scale-x-100"
-          />
-          <polyline
-            points="12 5 5 12 12 19"
-            class="translate-x-1 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-focus-visible:translate-x-0"
-          />
-        </svg>
-        <div class="flex items-center text-sm">{prevPost?.data.title}</div>
+        <ArrowIcon direction="left" size={5} />
+        <div class="line-clamp-2 min-w-0 text-sm">{prevPost?.data.title}</div>
       </a>
     ) : (
       <div class="invisible" />
@@ -36,27 +22,11 @@ const { prevPost, nextPost } = Astro.props;
   {
     nextPost?.id ? (
       <a
-        href={`/blog/${nextPost?.id}`}
-        class="group relative flex grow flex-row-reverse flex-nowrap rounded-lg border border-black/15 px-4 py-4 pr-10 no-underline transition-colors duration-300 ease-in-out hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black dark:border-white/20 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white"
+        href={`/blog/${nextPost?.id}/`}
+        class="group relative flex min-w-0 grow flex-row-reverse flex-nowrap rounded-lg px-4 py-3 pr-10 no-underline ghost-surface"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          class="absolute top-1/2 right-2 size-5 -translate-y-1/2 fill-none stroke-current stroke-2"
-        >
-          <line
-            x1="5"
-            y1="12"
-            x2="19"
-            y2="12"
-            class="translate-x-3 scale-x-0 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-hover:scale-x-100 group-focus-visible:translate-x-0 group-focus-visible:scale-x-100"
-          />
-          <polyline
-            points="12 5 19 12 12 19"
-            class="-translate-x-1 transition-transform duration-300 ease-in-out group-hover:translate-x-0 group-focus-visible:translate-x-0"
-          />
-        </svg>
-        <div class="flex items-center text-sm">{nextPost?.data.title}</div>
+        <ArrowIcon direction="right" size={5} />
+        <div class="line-clamp-2 min-w-0 text-sm">{nextPost?.data.title}</div>
       </a>
     ) : (
       <div class="invisible" />

--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -1,8 +1,0 @@
----
-import { getCollection } from "astro:content";
-const allPosts = await getCollection("blog");
-const allTags = allPosts.map((tag) => tag.data.tags).flat();
-console.log(allTags);
----
-
-<span> </span>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -39,6 +39,12 @@ export const PROJECTS: Metadata = {
     "A collection of my projects with links to repositories and live demos.",
 };
 
+export const EXPERIENCE: Metadata = {
+  TITLE: "Experience",
+  DESCRIPTION:
+    "Fausto Moya's software engineering career: building scalable backend systems across fintech, logistics, and e-commerce at companies from startups to global platforms.",
+};
+
 export const SOCIALS: Socials = [
   {
     NAME: "GitHub",
@@ -56,7 +62,7 @@ export const WORK_EXPERIENCE: WorkExperience = [
     role: "Software Engineer",
     technologies: ["Kotlin", "Spring", "MongoDB", "Kafka"],
     description:
-      "At Ahold Delhaize, I led the modernization of the workforce management tool, building a new integration using modern languages and techniques. I spearheaded efforts to improve code quality, promoting good coding practices and a test-driven development mindset.\nI played a key role in helping the team adopt agile methodologies, improving meeting efficiency and sharing agile knowledge to streamline processes. By fostering close collaboration between the business and development teams, I enabled better requirements gathering and greater ownership of projects.",
+      "I led the modernization of the workforce management tool, building a new integration with modern languages and techniques. I drove improvements in code quality, promoting good coding practices and a test-driven development mindset.\nI helped the team adopt agile methodologies, improving meeting efficiency and sharing agile knowledge to streamline processes. By fostering close collaboration between the business and development teams, I enabled better requirements gathering and greater ownership of projects.",
     start: new Date("2024-08-01"),
     end: null,
     link: "",
@@ -74,7 +80,7 @@ export const WORK_EXPERIENCE: WorkExperience = [
       "Github Actions",
     ],
     description:
-      "I led the design and implementation of a Trade Lane reporting and optimization tool, significantly enhancing data analysis and reporting capabilities. I optimized API response times, achieving a uniform 200 milliseconds for all data sets, compared to previous times of 2 seconds for small sets and 10 seconds for large sets.\nI successfully migrated 29 services to AWS, establishing infrastructure as code and implementing new CI/CD pipelines that resulted in a 30% reduction in operational costs. Additionally, I reduced deployment times by 25% through enhancements to the testing suite, GitHub Actions pipeline, and AWS Fargate integration, ensuring faster and more efficient software delivery.",
+      "I led the design and implementation of a Trade Lane reporting and optimization tool. I optimized API response times to a uniform 200 milliseconds for all data sets, down from 2 seconds for small sets and 10 seconds for large sets.\nI migrated 29 services to AWS, establishing infrastructure as code and new CI/CD pipelines that cut operational costs by 30%. I also reduced deployment times by 25% through improvements to the testing suite, the GitHub Actions pipeline, and AWS Fargate integration.",
     start: new Date("2022-05-01"),
     end: new Date("2024-08-01"),
     link: "",
@@ -84,7 +90,7 @@ export const WORK_EXPERIENCE: WorkExperience = [
     role: "Software Engineer",
     technologies: ["Java", "Kotlin", "SparkJava", "Lucene", "SQL"],
     description:
-      "As a Software Engineer at Mercado Libre, I led the development of innovative solutions that played a key role in the product's success. I designed and implemented scalable, robust, and maintainable systems that exceeded customer expectations, directly contributing to the company's growth. By utilizing modern technologies and agile methodologies, I consistently delivered high-quality results.\nThrough collaboration with cross-functional teams, we established and enforced best practices, striving for excellence in performance and continuous improvement. Notably, I improved store refresh speed by 50%, resulting in faster store indexing and a better customer experience.",
+      "I designed and implemented scalable, maintainable systems using modern technologies and agile methodologies. Working with cross-functional teams, we established and enforced best practices focused on performance and continuous improvement.\nNotably, I improved store refresh speed by 50%, resulting in faster store indexing and a better customer experience.",
     start: new Date("2021-05-01"),
     end: new Date("2022-05-01"),
     link: "",
@@ -101,7 +107,7 @@ export const WORK_EXPERIENCE: WorkExperience = [
       "AWS DynamoDB",
     ],
     description:
-      "As a Java Software Engineer at Ualá, I contributed to the development of robust and scalable software solutions that adhered to the highest industry standards. I leveraged modern technologies, including a full serverless infrastructure in AWS, and worked closely with my team using agile methodologies to deliver high-quality projects.\nA key part of my role was defining development standards and best practices to optimize the team's performance. I wrote clean and efficient code to ensure the optimal functioning of our solutions, which directly impacted Ualá's success. Throughout my experience, I deepened my knowledge of cutting-edge technologies and gained valuable insights into the software development process, consistently delivering results that exceeded expectations.",
+      "As a Java Software Engineer, I built scalable software on a full serverless infrastructure in AWS, working with my team using agile methodologies.\nI helped define development standards and best practices to improve the team's performance, and wrote clean, efficient code to keep our solutions running reliably.",
     start: new Date("2020-09-01"),
     end: new Date("2021-05-01"),
     link: "",
@@ -111,7 +117,7 @@ export const WORK_EXPERIENCE: WorkExperience = [
     role: "Software Engineer",
     technologies: ["Kotlin", "Spring", "Postgres", "ActiveMQ", "RxJava"],
     description:
-      "As a Kotlin Software Engineer at Rappi, I was part of a high-performing team that delivered innovative and efficient software solutions. My role involved developing new features, improving code, and fixing bugs, while collaborating closely with Scrum Masters and Project Managers to keep projects on track. I played a key role in integrating the app with various service providers, enabling offerings like Home Services, Video Conference Doctors, Games, and Sports Betting.\nIn addition to my development work, I provided technical guidance to my colleagues and mentored new team members. My contributions helped the team exceed expectations and positively impacted the development of scalable and robust software solutions for Rappi.",
+      "As a Kotlin Software Engineer, I developed new features, improved existing code, and fixed bugs, collaborating closely with Scrum Masters and Project Managers to keep projects on track. I integrated the app with various service providers, enabling offerings like Home Services, Video Conference Doctors, Games, and Sports Betting.\nAlongside my development work, I provided technical guidance to colleagues and mentored new team members.",
     start: new Date("2019-08-01"),
     end: new Date("2020-09-01"),
     link: "",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,16 +24,12 @@ const { title, description, lang } = Astro.props;
     />
   </head>
   <body>
-    <noscript>
-      <style>
-        .animate {
-          opacity: 1;
-          translate: var(--tw-translate-x) calc(var(--spacing) * 0);
-        }
-      </style>
-    </noscript>
+    <a
+      href="#main-content"
+      class="ghost-surface sr-only rounded-sm bg-neutral-100 px-3 py-2 text-sm focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-[var(--z-skip-link)] dark:bg-neutral-900"
+    >skip to content</a>
     <Header />
-    <main>
+    <main id="main-content">
       <slot />
     </main>
     <Footer />

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -66,17 +66,17 @@ const { Content, headings } = await render(post);
   <StructuredData type="breadcrumb" />
   <Container>
     <div class="animate">
-      <BackToPrevious href="/blog">Volver al blog</BackToPrevious>
+      <BackToPrevious href="/blog/">Volver al blog</BackToPrevious>
     </div>
     <div class="my-10 space-y-1">
       <div class="animate flex items-center gap-1.5">
         <div class="font-base text-sm">
-          <FormattedDate date={post.data.date} />
+          <FormattedDate date={post.data.date} lang="es" />
         </div>
         &bull;
         {
           post.body && (
-            <div class="font-base text-sm">{readingTime(post.body)}</div>
+            <div class="font-base text-sm">{readingTime(post.body, "es")}</div>
           )
         }
         &bull;
@@ -92,8 +92,8 @@ const { Content, headings } = await render(post);
           <div class="animate flex gap-2 pt-1">
             {post.data.tags.map((tag) => (
               <a
-                href={`/tags/${tag}`}
-                class="rounded-sm border border-black/15 px-2 py-1 text-sm transition-colors duration-300 ease-in-out hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black dark:border-white/20 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white"
+                href={`/tags/${tag}/`}
+                class="rounded-sm px-2 py-1 text-sm ghost-surface"
               >
                 {tag}
               </a>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -29,12 +29,17 @@ const years = Object.keys(posts).sort(
 
 <Layout title={BLOG.TITLE} description={BLOG.DESCRIPTION} lang="es">
   <Container>
-    <aside data-pagefind-ignore>
+    <div data-pagefind-ignore>
       <h1 class="animate text-3xl font-semibold text-black dark:text-white">
         Blog
       </h1>
       <div class="space-y-10">
         <div class="space-y-4">
+          {years.length === 0 && (
+            <p class="animate text-black/60 dark:text-white/60">
+              Aún no hay publicaciones. Vuelve pronto.
+            </p>
+          )}
           {
             years.map((year) => (
               <section class="animate space-y-4">
@@ -55,6 +60,6 @@ const years = Object.keys(posts).sort(
           }
         </div>
       </div>
-    </aside>
+    </div>
   </Container>
 </Layout>

--- a/src/pages/experience/index.astro
+++ b/src/pages/experience/index.astro
@@ -1,5 +1,5 @@
 ---
-import { HOME, WORK_EXPERIENCE } from "@consts";
+import { EXPERIENCE, WORK_EXPERIENCE } from "@consts";
 import Container from "@components/Container.astro";
 import Layout from "@layouts/Layout.astro";
 
@@ -12,9 +12,9 @@ function formatDate(date: Date | null): string {
 }
 ---
 
-<Layout title={HOME.TITLE} description={HOME.DESCRIPTION} lang="en">
+<Layout title={EXPERIENCE.TITLE} description={EXPERIENCE.DESCRIPTION} lang="en">
   <Container>
-    <aside data-pagefind-ignore>
+    <div data-pagefind-ignore>
       <section class="animate space-y-6">
         <div class="flex flex-wrap items-center justify-between gap-y-2">
           <h1 class="text-3xl font-semibold text-black dark:text-white">
@@ -25,9 +25,9 @@ function formatDate(date: Date | null): string {
       {
         WORK_EXPERIENCE.map((work) => (
           <article class="animate space-y-4 py-6">
-            <span class="text-xl font-semibold text-black dark:text-white">
+            <h2 class="text-xl font-semibold text-black dark:text-white">
               <strong>{work.role}</strong> @ {work.company}
-            </span>
+            </h2>
             <div class="text-sm opacity-75">
               From {formatDate(work.start)} to {formatDate(work.end)}
             </div>
@@ -41,6 +41,6 @@ function formatDate(date: Date | null): string {
           </article>
         ))
       }
-    </aside>
+    </div>
   </Container>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ const projects = (await getCollection("projects"))
 <Layout title={HOME.TITLE} description={HOME.DESCRIPTION} lang="en">
   <StructuredData type="person" />
   <Container>
-    <aside data-pagefind-ignore>
+    <div data-pagefind-ignore>
       <h1 class="animate text-3xl font-semibold text-black dark:text-white">
         Fausto Moya
       </h1>
@@ -30,46 +30,47 @@ const projects = (await getCollection("projects"))
           <article>
             <span class="animate">
               <p>
-                I <strong> designed, developed and deployed</strong> software for
-                diverse environments, from fast-moving startups to companies serving
-                millions. I thrive on turning <strong>complex challenges</strong
-                >
-                into <strong>meaningful solutions</strong>, demonstrated across
-                industries like fintech, logistics, and food delivery.
-              </p>
-            </span>
-            <span class="animate">
-              <p>
-                My journey has taken me from 🇦🇷 <strong>Argentina</strong> to exploring
-                new horizons in 🇳🇱 <strong>The Netherlands</strong>, gaining
-                valuable experience and building a second home. Here, I'm
-                currently <strong>improving scheduling</strong> and <strong
-                  >employee experience</strong
-                > for 1,270+ stores at <a
-                  href="https://www.aholddelhaize.com/about"
-                  target="_blank">Ahold Delhaize</a
-                >. Previously, I played a key role in <strong
-                  >cutting CO₂ emissions</strong
-                > with <a
-                  href="https://www.routescanner.com/about"
-                  target="_blank">Routescanner</a
-                > and delivered significant value at companies like <a
-                  href="https://news.mercadolibre.com/acercade">Mercado Libre</a
-                >, <a href="https://www.uala.com.ar/nosotros" target="_blank"
-                  >Ualá</a
-                >, and <a
-                  href="https://about.rappi.com/about-us"
-                  target="_blank">Rappi</a
+                I <strong> designed, developed and deployed</strong> software across
+                fast-moving startups and companies serving millions, in <strong
+                  >fintech</strong
+                >, <strong>logistics</strong>, and <strong>food delivery</strong
                 >.
               </p>
             </span>
             <span class="animate">
               <p>
-                Outside of work, I volunteer my time <strong>tutoring</strong> university
-                students in programming, databases, and testing. This passion for
-                sharing knowledge led me to create this blog – a resource aimed at
-                boosting everyone I've tutored and supporting the
-                <strong> Spanish-speaking</strong> software engineering community!
+                My journey took me from 🇦🇷 <strong>Argentina</strong> to 🇳🇱 <strong
+                  >The Netherlands</strong
+                >, where I built a second home. I'm currently <strong
+                  >improving scheduling</strong
+                > and <strong>employee experience</strong> for 1,270+ stores at <a
+                  href="https://www.aholddelhaize.com/about"
+                  target="_blank"
+                  rel="noopener noreferrer">Ahold Delhaize</a
+                >. Before that, I worked on <strong>cutting CO₂ emissions</strong
+                > at <a
+                  href="https://www.routescanner.com/about"
+                  target="_blank"
+                  rel="noopener noreferrer">Routescanner</a
+                >, and earlier at <a href="https://news.mercadolibre.com/acercade"
+                  >Mercado Libre</a
+                >, <a
+                  href="https://www.uala.com.ar/nosotros"
+                  target="_blank"
+                  rel="noopener noreferrer">Ualá</a
+                >, and <a
+                  href="https://about.rappi.com/about-us"
+                  target="_blank"
+                  rel="noopener noreferrer">Rappi</a
+                >.
+              </p>
+            </span>
+            <span class="animate">
+              <p>
+                Outside of work, I volunteer <strong>tutoring</strong> university students
+                in programming, databases, and testing. That's why I created this blog:
+                a resource for everyone I've tutored and for the
+                <strong> Spanish-speaking</strong> software engineering community.
               </p>
             </span>
           </article>
@@ -80,7 +81,7 @@ const projects = (await getCollection("projects"))
             <h2 class="font-semibold text-black dark:text-white">
               Latest posts
             </h2>
-            <Link href="/blog"> See all posts </Link>
+            <Link href="/blog/"> See all posts </Link>
           </div>
           <ul class="not-prose flex flex-col gap-4">
             {
@@ -98,7 +99,7 @@ const projects = (await getCollection("projects"))
             <h2 class="font-semibold text-black dark:text-white">
               Recent projects
             </h2>
-            <Link href="/projects"> See all projects </Link>
+            <Link href="/projects/"> See all projects </Link>
           </div>
           <ul class="not-prose flex flex-col gap-4">
             {
@@ -147,6 +148,6 @@ const projects = (await getCollection("projects"))
           </ul>
         </section>
       </div>
-    </aside>
+    </div>
   </Container>
 </Layout>

--- a/src/pages/projects/[...id].astro
+++ b/src/pages/projects/[...id].astro
@@ -30,7 +30,7 @@ const { Content, headings } = await render(project);
 >
   <Container>
     <div class="animate">
-      <BackToPrevious href="/projects">Back to projects</BackToPrevious>
+      <BackToPrevious href="/projects/">Back to projects</BackToPrevious>
     </div>
     <div class="animate my-10 space-y-1">
       <div class="flex items-center gap-1.5">

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -12,21 +12,25 @@ const projects = (await getCollection("projects"))
 
 <Layout title={PROJECTS.TITLE} description={PROJECTS.DESCRIPTION} lang="en">
   <Container>
-    <aside data-pagefind-ignore>
+    <div data-pagefind-ignore>
       <div class="space-y-10">
         <h1 class="animate text-3xl font-semibold text-black dark:text-white">
           Projects
         </h1>
-        <ul class="animate not-prose flex flex-col gap-4">
-          {
-            projects.map((project) => (
+        {projects.length === 0 ? (
+          <p class="animate text-black/60 dark:text-white/60">
+            No projects to show yet.
+          </p>
+        ) : (
+          <ul class="animate not-prose flex flex-col gap-4">
+            {projects.map((project) => (
               <li>
                 <ArrowCard entry={project} />
               </li>
-            ))
-          }
-        </ul>
+            ))}
+          </ul>
+        )}
       </div>
-    </aside>
+    </div>
   </Container>
 </Layout>

--- a/src/pages/tags/[id].astro
+++ b/src/pages/tags/[id].astro
@@ -26,14 +26,14 @@ const sortedPosts = posts.sort(
 
 <Layout
   title={`Tag: ${id}`}
-  description={`Posts with the tag: ${id}`}
+  description={`Publicaciones con el tag "${id}".`}
   lang="es"
 >
   <Container>
     <div class="space-y-10" data-pagefind-ignore>
-      <BackToPrevious href="/tags"> All tags </BackToPrevious>
+      <BackToPrevious href="/tags/"> Todos los tags </BackToPrevious>
       <h1 class="animate font-semibold text-black dark:text-white">
-        Posts tagged with "{id}"
+        Publicaciones con el tag "{id}"
       </h1>
       <ul class="animate flex flex-col gap-4">
         {sortedPosts.map((post) => <ArrowCard entry={post} />)}

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -9,16 +9,21 @@ const tags = [...new Set(posts.flatMap((post) => post.data.tags || []))].sort();
 <Layout title="Tags" description="Lista de los tags disponibles." lang="es">
   <Container>
     <div class="space-y-10">
-      <h1 class="animate font-semibold">All Tags</h1>
+      <h1 class="animate font-semibold">Todos los tags</h1>
+      {tags.length === 0 && (
+        <p class="animate text-black/60 dark:text-white/60">
+          Aún no hay tags.
+        </p>
+      )}
       <div class="animate flex flex-wrap gap-2">
         {
           tags.map((tag) => (
             <a
-              href={`/tags/${tag}`}
-              class="rounded-sm border border-black/15 px-2 py-1 text-sm transition-colors duration-300 ease-in-out hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black dark:border-white/20 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white"
+              href={`/tags/${tag}/`}
+              class="rounded-sm px-2 py-1 text-sm ghost-surface"
             >
               {tag}{" "}
-              <span class="text-sm text-gray-600">
+              <span class="text-sm text-black/60 dark:text-white/60">
                 ({posts.filter((post) => post.data.tags?.includes(tag)).length})
               </span>
             </a>

--- a/src/scripts/copy-code.ts
+++ b/src/scripts/copy-code.ts
@@ -19,12 +19,22 @@ export function init(): void {
   }
 
   for (const codeBlock of codeBlocks) {
+    // Skip blocks already processed on a prior `init()`. Without this, re-running
+    // on `astro:after-swap` re-wraps each `<pre>` and appends a second copy
+    // button. Freshly navigated pages have new `<pre>` nodes, so they process once.
+    if (codeBlock.dataset.copyReady) {
+      continue;
+    }
+    codeBlock.dataset.copyReady = "true";
+
     const wrapper = document.createElement("div");
     wrapper.style.position = "relative";
 
     const copyButton = document.createElement("button");
     copyButton.innerText = copyButtonLabel;
     copyButton.classList.add("copy-code");
+    copyButton.setAttribute("type", "button");
+    copyButton.setAttribute("aria-label", "Copiar código");
 
     codeBlock.setAttribute("tabindex", "0");
     codeBlock.appendChild(copyButton);

--- a/src/scripts/giscus.ts
+++ b/src/scripts/giscus.ts
@@ -8,6 +8,16 @@ export function setGiscusTheme(): void {
   giscus.src = url.toString();
 }
 
+let initialThemeSynced = false;
+
 export function init(): void {
+  // `setGiscusTheme()` rewrites the iframe `src`, which forces the giscus iframe
+  // to reload. Doing that on every `astro:after-swap` reloads comments on each
+  // navigation. Run the initial sync only once; later theme toggles still call
+  // `setGiscusTheme()` directly (from theme.ts) when the theme actually changes.
+  if (initialThemeSynced) {
+    return;
+  }
+  initialThemeSynced = true;
   setGiscusTheme();
 }

--- a/src/scripts/pagefind.ts
+++ b/src/scripts/pagefind.ts
@@ -1,46 +1,115 @@
-function openPagefind(): void {
+let lastTrigger: HTMLElement | null = null;
+
+function getDialog(): HTMLDialogElement | null {
+  return document.getElementById("pagefind-dialog") as HTMLDialogElement | null;
+}
+
+function getInput(): HTMLInputElement | null {
   const searchDiv = document.getElementById("search");
-  const search = searchDiv?.querySelector<HTMLInputElement>("input");
-  setTimeout(() => {
-    search?.focus();
-  }, 0);
-  const backdrop = document.getElementById("backdrop");
-  backdrop?.classList.remove("invisible");
-  backdrop?.classList.add("visible");
+  return searchDiv?.querySelector<HTMLInputElement>("input") ?? null;
+}
+
+const PAGEFIND_CSS = "/pagefind/pagefind-ui.css";
+const PAGEFIND_JS = "/pagefind/pagefind-ui.js";
+
+// Lazy-load the Pagefind UI bundle (CSS + JS, ~26KB) and mount it into #search.
+// Cached after the first call so reopening the modal never refetches or re-mounts.
+let uiPromise: Promise<void> | null = null;
+
+function loadPagefindUI(): Promise<void> {
+  if (uiPromise) {
+    return uiPromise;
+  }
+  uiPromise = new Promise<void>((resolve, reject) => {
+    if (!document.querySelector(`link[href="${PAGEFIND_CSS}"]`)) {
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = PAGEFIND_CSS;
+      document.head.appendChild(link);
+    }
+
+    const script = document.createElement("script");
+    script.src = PAGEFIND_JS;
+    script.onload = () => {
+      const PagefindUI = (
+        globalThis as unknown as {
+          PagefindUI?: new (options: Record<string, unknown>) => unknown;
+        }
+      ).PagefindUI;
+      if (!PagefindUI) {
+        reject(new Error("PagefindUI global missing after load"));
+        return;
+      }
+      // Mirrors the uiOptions previously passed to astro-pagefind's <Search>.
+      new PagefindUI({
+        element: "#search",
+        bundlePath: "/pagefind/",
+        showImages: false,
+        excerptLength: 15,
+        resetStyles: false,
+      });
+      resolve();
+    };
+    script.onerror = () => reject(new Error("Failed to load pagefind-ui.js"));
+    document.head.appendChild(script);
+  });
+  return uiPromise;
+}
+
+async function openPagefind(): Promise<void> {
+  const dialog = getDialog();
+  if (!dialog) {
+    return;
+  }
+  lastTrigger = document.activeElement as HTMLElement | null;
+  // Open immediately so the modal feels instant, then mount the UI into it.
+  if (!dialog.open) {
+    dialog.showModal();
+  }
+  try {
+    await loadPagefindUI();
+  } catch (error) {
+    console.error("Pagefind UI failed to load:", error);
+    return;
+  }
+  const input = getInput();
+  setTimeout(() => input?.focus(), 0);
 }
 
 function closePagefind(): void {
-  const searchDiv = document.getElementById("search");
-  const search = searchDiv?.querySelector<HTMLInputElement>("input");
-  if (search) {
-    search.value = "";
+  const input = getInput();
+  if (input) {
+    input.value = "";
   }
-  const backdrop = document.getElementById("backdrop");
-  backdrop?.classList.remove("visible");
-  backdrop?.classList.add("invisible");
+  getDialog()?.close();
 }
 
+let globalsWired = false;
+
 export function init(): void {
+  // Every listener below targets a persistent thing: `document`, the
+  // `#magnifying-glass` trigger (in the persisted header) and the persisted
+  // `#pagefind-dialog`. These survive `astro:after-swap`, so re-running `init()`
+  // would stack duplicate listeners. Wire them only on the first call.
+  if (globalsWired) {
+    return;
+  }
+  globalsWired = true;
+
   const magnifyingGlass = document.getElementById("magnifying-glass");
-  const backdrop = document.getElementById("backdrop");
+  const dialog = getDialog();
 
   magnifyingGlass?.addEventListener("click", () => {
-    openPagefind();
+    void openPagefind();
   });
 
   document.addEventListener("keydown", (e: KeyboardEvent) => {
     if (e.key === "/") {
       e.preventDefault();
-      openPagefind();
+      void openPagefind();
     } else if ((e.metaKey || e.ctrlKey) && e.key === "k") {
       e.preventDefault();
-      openPagefind();
-    }
-  });
-
-  document.addEventListener("keydown", (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      closePagefind();
+      void openPagefind();
     }
   });
 
@@ -51,11 +120,25 @@ export function init(): void {
     }
   });
 
-  backdrop?.addEventListener("click", (event: MouseEvent) => {
-    const target = event.target as HTMLElement;
-    if (!target.closest("#pagefind-container")) {
+  // The dialog IS the panel, so a click on the ::backdrop reports the
+  // dialog itself as the target.
+  dialog?.addEventListener("click", (event: MouseEvent) => {
+    if (event.target === dialog) {
       closePagefind();
     }
+  });
+
+  // Native <dialog> closes on Esc (firing both `cancel` and `close`).
+  // Centralize cleanup + focus return on the `close` event so it covers
+  // Esc, click-outside, and result-link clicks alike.
+  dialog?.addEventListener("close", () => {
+    const input = getInput();
+    if (input) {
+      input.value = "";
+    }
+    const fallback = document.getElementById("magnifying-glass");
+    (lastTrigger ?? fallback)?.focus();
+    lastTrigger = null;
   });
 
   const form = document.getElementById("form");

--- a/src/scripts/scroll.ts
+++ b/src/scripts/scroll.ts
@@ -6,7 +6,14 @@ function onScroll(): void {
   }
 }
 
+let scrollListenerWired = false;
+
 export function init(): void {
+  // Keep the initial sync each call so `.scrolled` is correct after navigation.
   onScroll();
-  document.addEventListener("scroll", onScroll);
+  // The scroll listener is document-level and persists across swaps; attach once.
+  if (!scrollListenerWired) {
+    scrollListenerWired = true;
+    document.addEventListener("scroll", onScroll, { passive: true });
+  }
 }

--- a/src/scripts/theme.ts
+++ b/src/scripts/theme.ts
@@ -56,6 +56,8 @@ function updateThemeButtons(): void {
   }
 }
 
+let mediaListenerWired = false;
+
 export function init(): void {
   updateThemeButtons();
 
@@ -80,11 +82,17 @@ export function init(): void {
     updateThemeButtons();
   });
 
-  window
-    .matchMedia("(prefers-color-scheme: dark)")
-    .addEventListener("change", (event) => {
-      if (localStorage.theme === "system") {
-        toggleTheme(event.matches);
-      }
-    });
+  // The matchMedia listener is window-level and persists across swaps, so
+  // attach it only once. The theme buttons above live in the (non-persisted)
+  // Footer, which is re-rendered each swap, so they must keep re-binding.
+  if (!mediaListenerWired) {
+    mediaListenerWired = true;
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", (event) => {
+        if (localStorage.theme === "system") {
+          toggleTheme(event.matches);
+        }
+      });
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,6 +7,10 @@
 @theme {
   --font-sans: var(--font-blog);
   --font-mono: var(--font-code);
+
+  /* z-index scale: header < skip-link < native dialog top-layer */
+  --z-header: 50;
+  --z-skip-link: 60;
 }
 
 /*
@@ -52,7 +56,7 @@
   }
 
   header {
-    @apply fixed top-0 right-0 left-0 z-50 py-6;
+    @apply fixed top-0 right-0 left-0 z-[var(--z-header)] py-6;
     @apply bg-neutral-100/75 dark:bg-neutral-900/75;
     @apply saturate-200 backdrop-blur-xs;
   }
@@ -84,13 +88,49 @@
   }
 }
 
+/*
+  Interactive ghost surface: the site's signature flat control treatment.
+  Hairline border, faint hover/focus wash, text resolves to full ink, full
+  light/dark parity. Composable with layout classes (rounded, padding, flex)
+  and an optional base background (e.g. the header search button).
+*/
+@utility ghost-surface {
+  @apply border border-black/15 transition-colors duration-300 ease-in-out;
+  @apply hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black;
+  @apply dark:border-white/20 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white;
+}
+
 .animate {
-  @apply -translate-y-3 opacity-0;
   @apply transition-all duration-300 ease-out;
 }
 
-.animate.show {
+html.js .animate {
+  @apply -translate-y-3 opacity-0;
+}
+
+html.js .animate.show {
   @apply translate-y-0 opacity-100;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.js .animate,
+  html.js .animate.show,
+  .animate,
+  .animate.show {
+    opacity: 1;
+    transform: none;
+    translate: none;
+    transition: none;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 html #back-to-top {
@@ -194,11 +234,11 @@ pre[class*="language-"] {
 
 /* copy code button on codeblocks */
 .copy-code {
-  @apply absolute top-3 right-3 grid size-9 place-content-center rounded-sm border border-black/15 bg-neutral-100 text-center duration-300 ease-in-out dark:border-white/20 dark:bg-neutral-900;
+  @apply absolute top-3 right-3 grid size-11 place-content-center rounded-sm border border-black/15 bg-neutral-100 text-center duration-300 ease-in-out dark:border-white/20 dark:bg-neutral-900;
 }
 
 .copy-code:hover {
-  @apply bg-[#E9E9E9] transition-colors dark:bg-[#232323];
+  @apply bg-neutral-200 transition-colors dark:bg-neutral-800;
 }
 
 .copy-code:active {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,36 @@
-export function readingTime(html: string) {
+export function readingTime(html: string, lang: "en" | "es" = "en") {
   const textOnly = html.replace(/<[^>]+>/g, "");
   const wordCount = textOnly.split(/\s+/).length;
   const readingTimeMinutes = (wordCount / 200 + 1).toFixed();
-  return `${readingTimeMinutes} min read`;
+  return lang === "es"
+    ? `${readingTimeMinutes} min de lectura`
+    : `${readingTimeMinutes} min read`;
+}
+
+/**
+ * Build the OG image URL for a page. Local replica of astro-opengraph-images'
+ * `getImagePath`, kept in-house so Head.astro doesn't import that package at
+ * request time: it eagerly loads @resvg/resvg-js (a native CJS addon) which
+ * throws "require is not defined" under Astro's dev/SSR ESM runner. The OG
+ * images themselves are still generated at build by the (build-only) integration.
+ */
+export function getImagePath({
+  url,
+  site,
+}: {
+  url: URL;
+  site: URL | undefined;
+}): string {
+  if (site === undefined) {
+    throw new Error(
+      "`site` must be set in your Astro configuration: https://docs.astro.build/en/reference/configuration-reference/#site",
+    );
+  }
+  let target = url.pathname;
+  // A trailing slash means a directory; otherwise append .png to the route.
+  target = target.endsWith("/") ? target + "index.png" : target + ".png";
+  // Astro emits these as top-level files rather than in a folder.
+  if (target === "/404/index.png") return site.toString() + "404.png";
+  if (target === "/500/index.png") return site.toString() + "500.png";
+  return site.toString() + target.slice(1);
 }

--- a/test/blog-post.spec.ts
+++ b/test/blog-post.spec.ts
@@ -34,6 +34,6 @@ test.describe("blog post page", () => {
     const backLink = page.getByRole("link", { name: "Volver al blog" });
     await expect(backLink).toBeVisible();
     await backLink.click();
-    await expect(page).toHaveURL("/blog");
+    await expect(page).toHaveURL("/blog/");
   });
 });

--- a/test/home.spec.ts
+++ b/test/home.spec.ts
@@ -39,13 +39,13 @@ test("has a link that redirects to my email address", async ({ page }) => {
 test("has a link that redirects to my blog", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("link", { name: "See all posts" }).click();
-  await expect(page).toHaveURL("/blog");
+  await expect(page).toHaveURL("/blog/");
 });
 
 test("has a link that redirects to my projects", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("link", { name: "See all projects" }).click();
-  await expect(page).toHaveURL("/projects");
+  await expect(page).toHaveURL("/projects/");
 });
 
 test("nav bar is visible", async ({ page }) => {

--- a/test/nav.spec.ts
+++ b/test/nav.spec.ts
@@ -9,13 +9,13 @@ test("my name in the nav bar redirects to home page", async ({ page }) => {
 test("blog in the nav bar redirects to blog page", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("link", { name: "blog" }).click();
-  await expect(page).toHaveURL("/blog");
+  await expect(page).toHaveURL("/blog/");
 });
 
 test("projects in the nav bar redirects to projects page", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("link", { name: "projects", exact: true }).click();
-  await expect(page).toHaveURL("/projects");
+  await expect(page).toHaveURL("/projects/");
 });
 
 test("experience in the nav bar redirects to experience page", async ({
@@ -23,7 +23,7 @@ test("experience in the nav bar redirects to experience page", async ({
 }) => {
   await page.goto("/");
   await page.getByRole("link", { name: "experience" }).click();
-  await expect(page).toHaveURL("/experience");
+  await expect(page).toHaveURL("/experience/");
 });
 
 test("nav is visible on all main pages", async ({ page }) => {

--- a/test/tags.spec.ts
+++ b/test/tags.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 test("should display the All Tags heading", async ({ page }) => {
   await page.goto("/tags");
   await expect(
-    page.getByRole("heading", { name: "All Tags" }),
+    page.getByRole("heading", { name: "Todos los tags" }),
   ).toBeVisible();
 });
 
@@ -28,7 +28,7 @@ test("should display filtered posts on tag detail page", async ({ page }) => {
   const href = await firstTag.getAttribute("href");
   await page.goto(href!);
   await expect(
-    page.getByRole("heading", { name: /Posts tagged with/ }),
+    page.getByRole("heading", { name: /Publicaciones con el tag/ }),
   ).toBeVisible();
   const posts = page.locator('a[href^="/blog/"]');
   expect(await posts.count()).toBeGreaterThan(0);

--- a/test/theme.spec.ts
+++ b/test/theme.spec.ts
@@ -6,7 +6,7 @@ test.describe("Theme persistence", () => {
     await page.getByRole("button", { name: "Dark theme" }).click();
     await expect(page.locator("html")).toHaveClass(/dark/);
     await page.getByRole("link", { name: "experience" }).click();
-    await expect(page).toHaveURL("/experience");
+    await expect(page).toHaveURL("/experience/");
     await expect(page.locator("html")).toHaveClass(/dark/);
   });
 
@@ -24,7 +24,7 @@ test.describe("Theme persistence", () => {
     await page.getByRole("button", { name: "Light theme" }).click();
     await expect(page.locator("html")).not.toHaveClass(/dark/);
     await page.getByRole("link", { name: "experience" }).click();
-    await expect(page).toHaveURL("/experience");
+    await expect(page).toHaveURL("/experience/");
     await expect(page.locator("html")).not.toHaveClass(/dark/);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,12 @@
   "exclude": ["dist"],
   "compilerOptions": {
     "strictNullChecks": true,
-    "baseUrl": ".",
     "paths": {
-      "@*": ["./src/*"]
+      "@components/*": ["./src/components/*"],
+      "@layouts/*": ["./src/layouts/*"],
+      "@consts": ["./src/consts.ts"],
+      "@types": ["./src/types.ts"],
+      "@utils": ["./src/utils.ts"]
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "buildCommand": "bun run build",
   "outputDirectory": "dist",
+  "trailingSlash": true,
   "headers": [
     {
       "source": "/_astro/(.*)",


### PR DESCRIPTION
## Summary

Large redesign of the blog/portfolio on the **astro-micro** theme (monochrome chrome, Geist Sans/Mono, full light/dark parity, bilingual ES/EN UI driven from `consts.ts`), plus Pagefind lazy-loading, font/cache tuning, and `PRODUCT.md` / `DESIGN.md` / `CLAUDE.md` docs.

It also fixes the **duplicate-URL indexing signals** seen in Google Search Console (`Alternate page with proper canonical tag`, `Crawled/Discovered – currently not indexed`).

## SEO fix — single canonical URL form

Every page was reachable at **two live 200 URLs** with no redirect between them:
- internal links pointed at the **no-slash** form (`/blog/x`)
- the canonical tag, sitemap, and `og:url` all declared the **slash** form (`/blog/x/`)

So Googlebot crawled the no-slash variants and filed them as "alternates", wasting crawl budget on a low-authority site.

Changes:
- **`vercel.json`**: `"trailingSlash": true` → prod 308-redirects `/path` → `/path/` (the form already declared by canonical/sitemap/og), so there is one URL per page.
- **internal links** (`ArrowCard`, `Header`, `PostNavigation`, page back-links, tag chips): now emit the slash form, so crawlers hit the canonical URL directly with no redirect hop.

> Note: `Crawled – currently not indexed` on the canonical pages is largely a young-site authority/content signal — this removes the technical obstacle and the duplicate noise, but won't by itself force those pages in. After deploy: resubmit `sitemap-index.xml` and "Validar corrección" in GSC. (`simpsonizado.moyis.dev` in the report is a separate subdomain, out of scope.)

## Tests

- Updated Playwright `toHaveURL` assertions to the slash form (`nav`, `home`, `blog-post`, `theme`).
- Aligned two `tags` spec assertions to the shipped Spanish headings (`Todos los tags`, `Publicaciones con el tag`) the redesign introduced.
- Full suite green locally: **106 passed** (chromium + Mobile Chrome).

## Verify after deploy

```
curl -sI https://moyis.dev/blog/long-methods | grep -i location   # expect 308 -> /blog/long-methods/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)